### PR TITLE
cheaper cancel - no need for sig verification

### DIFF
--- a/contracts/ADXExchange.sol
+++ b/contracts/ADXExchange.sol
@@ -151,15 +151,13 @@ contract ADXExchange is ADXExchangeInterface, Drainable {
 	}
 
 	// The bid is canceled by the advertiser
-	function cancelBid(bytes32 _adunit, uint _opened, uint _target, uint _amount, uint _timeout, uint8 v, bytes32 r, bytes32 s, uint8 sigMode)
+	function cancelBid(bytes32 _adunit, uint _opened, uint _target, uint _amount, uint _timeout)
 		public
 	{
 		// _opened acts as a nonce here
 		bytes32 bidId = getBidID(msg.sender, _adunit, _opened, _target, _amount, _timeout);
 
 		require(bidStates[bidId] == BidState.DoesNotExist);
-
-		require(didSign(msg.sender, bidId, v, r, s, sigMode));
 
 		bidStates[bidId] = BidState.Canceled;
 

--- a/contracts/ADXExchangeInterface.sol
+++ b/contracts/ADXExchangeInterface.sol
@@ -12,7 +12,7 @@ contract ADXExchangeInterface {
 	event LogWithdrawal(address _user, uint _amnt);
 
 	function acceptBid(address _advertiser, bytes32 _adunit, uint _opened, uint _target, uint _rewardAmount, uint _timeout, bytes32 _adslot, uint8 v, bytes32 r, bytes32 s, uint8 sigMode) public;
-	function cancelBid(bytes32 _adunit, uint _opened, uint _target, uint _rewardAmount, uint _timeout, uint8 v, bytes32 r, bytes32 s, uint8 sigMode) public;
+	function cancelBid(bytes32 _adunit, uint _opened, uint _target, uint _rewardAmount, uint _timeout) public;
 	function giveupBid(bytes32 _bidId) public;
 	function refundBid(bytes32 _bidId) public;
 	function verifyBid(bytes32 _bidId, bytes32 _report) public;

--- a/test/01_exchange.js
+++ b/test/01_exchange.js
@@ -319,7 +319,7 @@ contract('ADXExchange', function(accounts) {
 			s = '0x'+resp.substring(64, 128)
 			v = parseInt(resp.substring(128, 130), 16) + 27
 
-			return adxExchange.cancelBid('0x1', bidOpened, 500, 5, 0, '0x'+v.toString(16), r, s, 1, { from: acc })
+			return adxExchange.cancelBid('0x1', bidOpened, 500, 5, 0, { from: acc })
 		})
 		.then(function(resp) {
 			var ev = resp.logs[0]


### PR DESCRIPTION
Since the order is hashed from the msg.sender, there is no need to verify the sig again